### PR TITLE
fix int, forgot ontario

### DIFF
--- a/models/core/int_union_scrum_badges.sql
+++ b/models/core/int_union_scrum_badges.sql
@@ -1,6 +1,6 @@
 with final_scrum_badges as (
     {{ dbt_utils.union_relations(
-        relations=[ref('stg_credly__credly_scrum_badges_quebec'), ref('stg_credly__credly_scrum_badges_quebec')]
+        relations=[ref('stg_credly__credly_scrum_badges_quebec'), ref('stg_credly__credly_scrum_badges_ontario')]
     ) }}
 ),
 


### PR DESCRIPTION
fix models/core/int_union_scrum_badges.sql as it was union quebec twice where it should have included ontario